### PR TITLE
Update GitHub2.css

### DIFF
--- a/GitHub2.css
+++ b/GitHub2.css
@@ -162,12 +162,10 @@ table {
     table tr th {
       font-weight: bold;
       border: 1px solid #cccccc;
-      text-align: left;
       margin: 0;
       padding: 6px 13px; }
     table tr td {
       border: 1px solid #cccccc;
-      text-align: left;
       margin: 0;
       padding: 6px 13px; }
     table tr th :first-child, table tr td :first-child {
@@ -280,4 +278,12 @@ pre {
         width: 854px;
         margin:0 auto;
     }
+}
+@media print {
+  table, pre {
+		page-break-inside: avoid;
+	}
+	pre {
+		word-wrap: break-word;
+	}
 }


### PR DESCRIPTION
- Removed "text-align: left;" for table in order to get the alignment colons syntax works.
- Add @media print rule for a better PDF export result.
